### PR TITLE
Optimize Reduce operation on pressure equation

### DIFF
--- a/include/PressureEquation.h
+++ b/include/PressureEquation.h
@@ -23,7 +23,7 @@ namespace mif {
     // Remove a constant from the pressure to obtain the exact solution.
     // If needed, this will use MPI communication with tag 0.
     void adjust_pressure(StaggeredTensor &pressure,
-                         const std::function<Real(Real, Real, Real)> &exact_pressure);
+                         const std::function<Real(Real, Real, Real)> &exact_pressure) noexcept;
 }
 
 #endif // PRESSURE_EQUATION_H


### PR DESCRIPTION
Replaced multiple `MPI_Send` and `MPI_Recv` calls with a single `MPI_Reduce` and `MPI_Bcast` to optimize the communication and reduce the number of messages sent.


Noticeable performance improvement in my machine:full_test 32 1000 6  goes from 28s to 23